### PR TITLE
Implement preliminary UI for videos, with upcoming and live pages

### DIFF
--- a/lib/src/main_application.dart
+++ b/lib/src/main_application.dart
@@ -4,6 +4,8 @@ import 'package:streamscheduler/src/pages/sign_in_page.dart';
 import 'pages/home_page.dart';
 import 'pages/subscriptions_page.dart';
 import 'model/shared_app_state.dart';
+import 'pages/upcoming_page.dart';
+import 'pages/live_page.dart';
 
 class MainApplication extends StatefulWidget {
   const MainApplication({super.key, required this.title});
@@ -48,6 +50,12 @@ class _MainApplicationState extends State<MainApplication> {
       case 1:
         _page = SubscriptionsPage();
         break;
+      case 2:
+        _page = UpcomingPage();
+        break;
+      case 3:
+        _page = LivePage();
+        break;
       default:
         throw UnimplementedError('no widget for $_selectedIndex');
     }
@@ -71,7 +79,7 @@ class _MainApplicationState extends State<MainApplication> {
                   minExtendedWidth: 200,
                   backgroundColor: theme.colorScheme.onBackground,
                   destinations: [
-                    NavigationRailDestination(
+                    NavigationRailDestination( //index 0
                         icon: Icon(
                           Icons.home_outlined,
                           color: theme.colorScheme.background,
@@ -84,7 +92,7 @@ class _MainApplicationState extends State<MainApplication> {
                           "Home",
                           style: style,
                         )),
-                    NavigationRailDestination(
+                    NavigationRailDestination( //index 1
                         icon: Icon(
                           Icons.subscriptions_outlined,
                           color: theme.colorScheme.background,
@@ -94,6 +102,26 @@ class _MainApplicationState extends State<MainApplication> {
                           color: theme.colorScheme.onBackground,
                         ),
                         label: Text("Subscriptions", style: style)),
+                    NavigationRailDestination( //index 2
+                        icon: Icon(
+                          Icons.upcoming_outlined,
+                          color: theme.colorScheme.background,
+                        ),
+                        selectedIcon: Icon(
+                          Icons.upcoming,
+                          color: theme.colorScheme.onBackground,
+                        ),
+                        label: Text("Upcoming", style: style)),
+                    NavigationRailDestination( //index 3
+                        icon: Icon(
+                          Icons.live_tv_outlined,
+                          color: theme.colorScheme.background,
+                        ),
+                        selectedIcon: Icon(
+                          Icons.live_tv,
+                          color: theme.colorScheme.onBackground,
+                        ),
+                        label: Text("Live", style: style)),
                   ],
                   selectedIndex: _selectedIndex,
                   onDestinationSelected: (value) {

--- a/lib/src/pages/components/broadcast_card.dart
+++ b/lib/src/pages/components/broadcast_card.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import '../../model/broadcast_item.dart';
+
+class BroadcastCard extends StatelessWidget {
+  const BroadcastCard({super.key, required this.broadcastItem});
+  final BroadcastItem broadcastItem;
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+    final style = theme.textTheme.bodyMedium!.copyWith(
+      color: Colors.black,
+    );
+
+    return Card(
+        shape: const RoundedRectangleBorder(
+            side: BorderSide(
+          color: Colors.black,
+        )),
+        color: Colors.white,
+        child: Padding(
+          padding: const EdgeInsets.all(5.0),
+          child: Column(
+            children: [
+              Expanded(
+                  child: Image.network(
+                broadcastItem.getThumbnailUrl(),
+              )),
+              const SizedBox(
+                height: 10,
+              ),
+              Row(
+                children: [
+                  Flexible(
+                    child: Text(
+                      broadcastItem.getVideoTitle(),
+                      style: style,
+                    ),
+                  ),
+                ],
+              ),
+            ],
+          ),
+        ));
+  }
+}

--- a/lib/src/pages/home_page.dart
+++ b/lib/src/pages/home_page.dart
@@ -1,67 +1,13 @@
 import 'package:flutter/material.dart';
-import 'package:provider/provider.dart';
-import '../model/shared_app_state.dart';
-import 'package:googleapis/youtube/v3.dart';
-import 'package:mobx/mobx.dart';
-import 'package:flutter_mobx/flutter_mobx.dart';
-import '../model/subscription_item.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    var sharedState = context.watch<SharedAppState>();
-    final theme = Theme.of(context);
-    final style = theme.textTheme.bodyMedium!.copyWith(
-      color: Colors.black,
-    );
 
-    return Center(
-      child: Column(
-        children: [
-          const SizedBox(
-            height: 10,
-          ),
-          ElevatedButton(
-              onPressed: () {
-                sharedState.updateTrackedChannels();
-              },
-              child: Text("refresh")),
-          const SizedBox(
-            height: 10,
-          ),
-          Observer(
-              builder: (_) => Text(
-                    "____________________LIVE: ${sharedState.liveStreams.length}____________________",
-                  )),
-          Observer(
-              builder: (_) => Column(
-                    children: sharedState.liveStreams
-                        .map((element) => Text(
-                              element.getVideoTitle(),
-                              style: style,
-                            ))
-                        .toList(),
-                  )),
-          const SizedBox(
-            height: 20,
-          ),
-          Observer(
-              builder: (_) => Text(
-                    "____________________UPCOMING: ${sharedState.upcomingStreams.length}____________________",
-                  )),
-          Observer(
-              builder: (_) => Column(
-                    children: sharedState.upcomingStreams
-                        .map((element) => Text(
-                              element.getVideoTitle(),
-                              style: style,
-                            ))
-                        .toList(),
-                  )),
-        ],
-      ),
+    return const Center(
+      child: Text("PLACEHOLDER FOR HOME PAGE. THIS WILL CONTAIN CONTENT SUMMARY IN FUTURE IMPLEMENTATION."),
     );
   }
 }

--- a/lib/src/pages/live_page.dart
+++ b/lib/src/pages/live_page.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../model/shared_app_state.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
+import 'components/broadcast_card.dart';
+
+class LivePage extends StatelessWidget {
+  const LivePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    var sharedState = context.watch<SharedAppState>();
+    final theme = Theme.of(context);
+    final style = theme.textTheme.bodyMedium!.copyWith(
+      color: Colors.black,
+    );
+
+    return Column(
+      children: [
+        ElevatedButton(
+                  onPressed: () {
+                    sharedState.updateTrackedChannels();
+                  },
+                  child: Text("refresh")),
+        Observer(
+            builder: (_) =>
+                Text("____________________LIVE: ${sharedState.liveStreams.length}____________________")),
+        Expanded(
+          child: Row(
+            children: [
+              Expanded(
+                  child: Observer(
+                builder: (_) => GridView(
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 5,
+                      crossAxisSpacing: 4.0,
+                      mainAxisSpacing: 8.0),
+                  children: sharedState.liveStreams.map((element) => BroadcastCard(broadcastItem: element)).toList(),
+                ),
+              )),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/src/pages/upcoming_page.dart
+++ b/lib/src/pages/upcoming_page.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:provider/provider.dart';
+import '../model/shared_app_state.dart';
+import 'package:flutter_mobx/flutter_mobx.dart';
+import 'components/broadcast_card.dart';
+
+class UpcomingPage extends StatelessWidget {
+  const UpcomingPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    var sharedState = context.watch<SharedAppState>();
+    final theme = Theme.of(context);
+    final style = theme.textTheme.bodyMedium!.copyWith(
+      color: Colors.black,
+    );
+
+    return Column(
+      children: [
+        ElevatedButton(
+                  onPressed: () {
+                    sharedState.updateTrackedChannels();
+                  },
+                  child: Text("refresh")),
+        Observer(
+            builder: (_) =>
+                Text("____________________UPCOMING: ${sharedState.upcomingStreams.length}____________________")),
+        Expanded(
+          child: Row(
+            children: [
+              Expanded(
+                  child: Observer(
+                builder: (_) => GridView(
+                  gridDelegate: const SliverGridDelegateWithFixedCrossAxisCount(
+                      crossAxisCount: 5,
+                      crossAxisSpacing: 4.0,
+                      mainAxisSpacing: 8.0),
+                  children: sharedState.upcomingStreams.map((element) => BroadcastCard(broadcastItem: element)).toList(),
+                ),
+              )),
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/web/index.html
+++ b/web/index.html
@@ -1,8 +1,5 @@
 <!DOCTYPE html>
 <html>
-  <script type="text/javascript">
-    window.flutterWebRenderer = "html";
-  </script>
 <head>
   <!--
     If you are serving your web app in a path other than the root, change the


### PR DESCRIPTION
This PR implements the preliminary version of `BroadcastCard` to display broadcast elements. Home page now no longer displays upcoming and live streams, and these are moved to upcoming and live pages respectively.